### PR TITLE
Updates zip vs. tar imports (semi fixes #44)

### DIFF
--- a/scripts/data-shippers/Mordor-Elastic.py
+++ b/scripts/data-shippers/Mordor-Elastic.py
@@ -4,6 +4,7 @@
 from argparse import ArgumentParser
 from pathlib import Path
 import tarfile
+import zipfile
 import json
 import progressbar
 import sys
@@ -36,11 +37,8 @@ if args.output == "elasticsearch":
             )
     if  args.create_index:
         es.indices.create(
-                index,
-                body={ "settings": {
-                            "index.mapping.total_fields.limit": 2000
-                        }
-                    }
+                index=index,
+                body= { "settings": { "index.mapping.total_fields.limit": 2000 } }
             )
 elif args.output == "logstash":
     #Only import requests when logstash is used
@@ -60,126 +58,180 @@ else:
     print("Output type was not recognized. Exiting...")
     sys.exit()
 
+paths = []
+types = ('.gz', '.zip')
 if args.recursive:
-    paths = [ p for path in args.inputs for p in path.glob("**/*.tar.gz") if p.is_file() ]
+    for path in args.inputs:
+        for p in path.glob(f"**/*"):
+            if p.is_file() and p.suffix in types:
+                paths.append(p)
 else:
     paths = [ path for path in args.inputs if path.is_file() ]
 
+
 print("Calulating total file size...")
-total_size = sum([
-    member.size
-    for path in progressbar.progressbar(paths)
-    for member in tarfile.open(path).getmembers() if member.isfile()
-    ])
+def sum(paths):
+    total_size = 0
+    for path in progressbar.progressbar(paths):
+        if tarfile.is_tarfile(path):
+            for member in tarfile.open(path).getmembers():
+                if member.isfile():
+                    total_size += member.size
+        elif zipfile.is_zipfile(path):
+            for member in zipfile.ZipFile(path).filelist:
+                total_size += member.file_size
+        else:
+            total_size += path.stat().st_size
+    return total_size
+
+total_size = sum(paths)
+print(total_size)
 
 total_success = 0
 total_failed = 0
 
+disallowed_extensions = ['.cap', '.pcap', '.sha1sum', '.pcapng']
 with progressbar.DataTransferBar(max_value=total_size) as progress:
     for path in paths:
         print(f"Importing dataset {path}")
-        tf = tarfile.open(path)
-        for m in tf.getmembers():
-            if m.isfile():
-                print(f"- Importing member file {m.name}...")
-                logfile = f"{path}/{m.name}"
-                mf = tf.extractfile(m)
-                def generate_actions(f, progress):
-                    for line in f:
+        if tarfile.is_tarfile(path):
+            tf = tarfile.open(path)
+            members = tf.getmembers()
+        elif zipfile.is_zipfile(path):
+            zf = zipfile.ZipFile(path)
+            members = [f.filename for f in zf.filelist]
+        else:
+            members = [path]
+
+        for m in members:
+            if tarfile.is_tarfile(path):
+                if not m.isfile() or Path(m.name).suffix in disallowed_extensions:
+                    continue
+                else:
+                    print(f"- Importing member file {m.name}...")
+                    logfile = f"{path}/{m.name}"
+                    mf = tf.extractfile(m)
+            elif zipfile.is_zipfile(path):
+                if m.endswith('/') or Path(m).suffix in disallowed_extensions:
+                    continue
+                else:
+                    print(f"- Importing member file {m}...")
+                    logfile = f"{path}/{m}"
+                    mf = zf.open(m)
+            else:
+                if not Path(m).is_file() or Path(m).suffix in disallowed_extensions:
+                    continue
+                else:
+                    print(f"- Importing member file {m}...")
+                    logfile = f"{m}"
+                    mf = open(m)
+
+            def generate_actions(f, progress):
+                for line in f:
+                    try:
                         source = json.loads(line)
-                        source["log"] = { "file": { "name": logfile }}
-                        source.setdefault("winlog", dict())
+                    except json.decoder.JSONDecodeError as e:
+                        # This allows for pushing in raw logs (e.g. Zeek from compound dataset apt29)
+                        source = { "message": line }
+                    source["log"] = { "file": { "name": logfile }}
+                    source.setdefault("winlog", dict())
 
-                        # Plain data created by nxlog is completely moved to winlog.event_data except blacklisted
-                        if "EventID" in source:
-                            # Move event id to appropriate location
-                            source["winlog"]["event_id"] = source["EventID"]
-                            del source["EventID"]
+                    # Plain data created by nxlog is completely moved to winlog.event_data except blacklisted
+                    if "EventID" in source:
+                        # Move event id to appropriate location
+                        source["winlog"]["event_id"] = source["EventID"]
+                        del source["EventID"]
 
-                            # Discard unneeded fields
-                            try:
-                                del source["type"]
-                            except KeyError:
-                                pass
-
-                            try:
-                                del source["host"]
-                            except KeyError:
-                                pass
-
-                            # Move fields from top level to winlog.event_data
-                            source["winlog"]["event_data"] = {
-                                        k: v
-                                        for k, v in source.items()
-                                        if k not in ("winlog", "log", "Channel", "Hostname", "@timestamp", "@version")
-                                    }
-                            for k in source["winlog"]["event_data"].keys():
-                                del source[k]
-
-                            # Special handling for host name
-                            try:
-                                source["winlog"]["computer_name"] = source["Hostname"]
-                                del source["Hostname"]
-                            except KeyError:
-                                pass
-
-                            # Special handling for channel
-                            try:
-                                source["winlog"]["channel"] = source["Channel"]
-                                del source["Channel"]
-                            except KeyError:
-                                pass
-
-                        # Data created with Winlogbeat <7 contains event fields in event_data instead of winlog.event_data - move it
-                        if "event_data" in source:
-                            source["winlog"]["event_data"] = source["event_data"]
-                            del source["event_data"]
-                        # Old Winlogbeats also put the channel name in the log_name field move this to new field names
-                        if "log_name" in source:
-                            source["winlog"]["channel"] = source["log_name"]
-                            del source["log_name"]
-                        # Some log records contain the channel name "security" in small letters, fix this
+                        # Discard unneeded fields
                         try:
-                            if source["winlog"]["channel"] == "security":
-                                source["winlog"]["channel"] = "Security"
+                            del source["type"]
                         except KeyError:
                             pass
-                        # Old Winlogbeats also put the event id in a different location, move it to the new one
-                        if "event_id" in source:
-                            source["winlog"]["event_id"] = source["event_id"]
-                            del source["event_id"]
+
+                        try:
+                            del source["host"]
+                        except KeyError:
+                            pass
+
+                        # Move fields from top level to winlog.event_data
+                        source["winlog"]["event_data"] = {
+                                    k: v
+                                    for k, v in source.items()
+                                    if k not in ("winlog", "log", "Channel", "Hostname", "@timestamp", "@version")
+                                }
+                        for k in source["winlog"]["event_data"].keys():
+                            del source[k]
+
+                        # Special handling for host name
+                        try:
+                            source["winlog"]["computer_name"] = source["Hostname"]
+                            del source["Hostname"]
+                        except KeyError:
+                            pass
+
+                        # Special handling for channel
+                        try:
+                            source["winlog"]["channel"] = source["Channel"]
+                            del source["Channel"]
+                        except KeyError:
+                            pass
+
+                    # Data created with Winlogbeat <7 contains event fields in event_data instead of winlog.event_data - move it
+                    if "event_data" in source:
+                        source["winlog"]["event_data"] = source["event_data"]
+                        del source["event_data"]
+                    # Old Winlogbeats also put the channel name in the log_name field move this to new field names
+                    if "log_name" in source:
+                        source["winlog"]["channel"] = source["log_name"]
+                        del source["log_name"]
+                    # Some log records contain the channel name "security" in small letters, fix this
+                    try:
+                        if source["winlog"]["channel"] == "security":
+                            source["winlog"]["channel"] = "Security"
+                    except KeyError:
+                        pass
+                    # Old Winlogbeats also put the event id in a different location, move it to the new one
+                    if "event_id" in source:
+                        source["winlog"]["event_id"] = source["event_id"]
+                        del source["event_id"]
                         # Also set event.code to event id
                         source.setdefault("event", dict())["code"] = source["winlog"]["event_id"]
 
-                        progress.update(progress.value + len(line))
-                        if args.output == "elasticsearch":
-                            yield {
-                                    "_index": index,
-                                    "_source": source
-                                }
-                        elif args.output == "logstash":
-                            yield source
-                if args.output == "elasticsearch":
-                    success_count, fail_count = bulk(es, generate_actions(mf, progress), True, raise_on_error=False)
-                    total_success += success_count
-                    total_failed += fail_count
-                    if fail_count > 0:
-                        color = "red"
-                    else:
+                    progress.update(progress.value + len(line))
+                    if args.output == "elasticsearch":
+                        yield {
+                                "_index": index,
+                                "_source": source
+                            }
+                    elif args.output == "logstash":
+                        yield source
+            if args.output == "elasticsearch":
+                success_count, fail_count = bulk(es, generate_actions(mf, progress), True, raise_on_error=False)
+                total_success += success_count
+                total_failed += fail_count
+                if fail_count > 0:
+                    color = "red"
+                else:
+                    color = "green"
+            elif args.output == "logstash":
+                fail_count = 0
+                success_count = 0
+                for event in generate_actions(mf, progress):
+                    r = requests.post(logstash_url, json=event, verify=verify_certs)
+                    if r.status_code == 200:
+                        success_count += 1
+                        total_success += 1
                         color = "green"
-                elif args.output == "logstash":
-                    fail_count = 0
-                    success_count = 0
-                    for event in generate_actions(mf, progress):
-                        r = requests.post(logstash_url, json=event, verify=verify_certs)
-                        if r.status_code == 200:
-                            success_count += 1
-                            total_success += 1
-                            color = "green"
-                        else:
-                            fail_count += 1
-                            total_failed += 1
-                            color = "red"
-                print(colored(f"- Imported {success_count} events, {fail_count} failed", color))
-        tf.close()
+                    else:
+                        fail_count += 1
+                        total_failed += 1
+                        color = "red"
+            print(colored(f"- Imported {success_count} events, {fail_count} failed", color))
+        if tarfile.is_tarfile(path):
+            tf.close()
+        elif zipfile.is_zipfile(path):
+            zf.close()
+        else:
+            pass
+        
 print(f"Imported {total_success} log records, {total_failed} failed.")


### PR DESCRIPTION
This is by no means a full/clean fix for #44 but allows to at least push in most textual datasets straight from a file (.log / .json) as well as from a zip or tar archive.

Main remaining issues seem to be caused by import errors when things like timestamp fields conflict with the index or other datasets one is trying to push. For example adding two datasets from `datasets/atomic/windows/defense_evasion/host/` directory.
```
{'error': {'type': 'mapper_parsing_exception', 'reason': "failed to parse field [winlog.event_data.TimeCreated] of type [date] in document with id 'bkY71X8B_OeruxpihSOU'. Preview of field's value: '2020-10-21 12:19:04.554'", 'caused_by': {'type': 'illegal_argument_exception', 'reason': 'failed to parse date field [2020-10-21 12:19:04.554] with format [strict_date_optional_time||epoch_millis]', 'caused_by': {'type': 'date_time_parse_exception', 'reason': 'Failed to parse with all enclosed parsers'}}}}
```
![image](https://user-images.githubusercontent.com/17042203/160596790-e9ee8c18-43b5-46c8-bb80-9674a184257c.png)


**Some successful imports:**
![recursive_zip](https://user-images.githubusercontent.com/17042203/160593504-a38ba177-e02b-4005-87bc-9084e963bc2b.png)
![single_file_json](https://user-images.githubusercontent.com/17042203/160593508-e8dd969e-0959-40f8-8739-7004765222c3.png)
![single_file_log](https://user-images.githubusercontent.com/17042203/160593511-2095a58c-b192-460c-a136-baff357715c3.png)
![single_file_tar](https://user-images.githubusercontent.com/17042203/160593516-de04784b-e731-4525-8a29-7ba0ac116a75.png)
